### PR TITLE
Mute Taglib Output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
  "diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.9.0 (git+https://github.com/mitsuhiko/indicatif.git?rev=950091d1b1683a88e01c4d4975f591009f56322b)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_iron 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "indicatif"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/mitsuhiko/indicatif.git?rev=950091d1b1683a88e01c4d4975f591009f56322b#950091d1b1683a88e01c4d4975f591009f56322b"
 dependencies = [
  "console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1345,7 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebdff791af04e30089bde8ad2a632b86af433b40c04db8d70ad4b21487db7a6a"
-"checksum indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a29b2fa6f00010c268bface64c18bb0310aaa70d46a195d5382d288c477fb016"
+"checksum indicatif 0.9.0 (git+https://github.com/mitsuhiko/indicatif.git?rev=950091d1b1683a88e01c4d4975f591009f56322b)" = "<none>"
 "checksum inflate 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec18d981200fd14e65ee8e35fb60ed1ce55227a02407303f3a72517c6146dcc"
 "checksum iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8e17268922834707e1c29e8badbf9c712c9c43378e1b6a3388946baff10be2"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ r2d2-diesel = "1.0.0"
 taglib2-sys = { path = "taglib2-sys" }
 error-chain = "0.11.0"
 walkdir = "2.1.4"
-indicatif = "0.9.0"
+indicatif = { git = "https://github.com/mitsuhiko/indicatif.git", rev = "950091d1b1683a88e01c4d4975f591009f56322b" }
 router = "0.6.0"
 iron = "0.6.0"
 logger = "0.4.0"

--- a/fixture_setup/Cargo.lock
+++ b/fixture_setup/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
  "diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.9.0 (git+https://github.com/mitsuhiko/indicatif.git?rev=950091d1b1683a88e01c4d4975f591009f56322b)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_iron 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "indicatif"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/mitsuhiko/indicatif.git?rev=950091d1b1683a88e01c4d4975f591009f56322b#950091d1b1683a88e01c4d4975f591009f56322b"
 dependencies = [
  "console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1376,7 +1376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebdff791af04e30089bde8ad2a632b86af433b40c04db8d70ad4b21487db7a6a"
-"checksum indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a29b2fa6f00010c268bface64c18bb0310aaa70d46a195d5382d288c477fb016"
+"checksum indicatif 0.9.0 (git+https://github.com/mitsuhiko/indicatif.git?rev=950091d1b1683a88e01c4d4975f591009f56322b)" = "<none>"
 "checksum inflate 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec18d981200fd14e65ee8e35fb60ed1ce55227a02407303f3a72517c6146dcc"
 "checksum iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8e17268922834707e1c29e8badbf9c712c9c43378e1b6a3388946baff10be2"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"

--- a/src/bin/sync.rs
+++ b/src/bin/sync.rs
@@ -57,12 +57,10 @@ pub fn sync(pool: context::Pool, path: &Path, artwork_directory: &Path) -> Resul
     bar.set_style(
         ProgressStyle::default_bar()
             .template(
-                "{prefix}[{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} ({eta})\n {msg}",
+                "[{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} ({eta})\n {msg}",
             )
             .progress_chars("#>-"),
     );
-
-    let mut prefix = String::new();
 
     bar.wrap_iter(entries.iter()).for_each(|dir_entry| {
         let path = dir_entry.path();
@@ -72,8 +70,7 @@ pub fn sync(pool: context::Pool, path: &Path, artwork_directory: &Path) -> Resul
         bar.set_message(message.as_str());
 
         if let Err(e) = handle_entry(path, artwork_directory, &conn) {
-            prefix = prefix.clone() + &format!("Error importing '{}': {}\n", path_string, e);
-            bar.set_prefix(prefix.as_str())
+            bar.println(format!("Error importing '{}': {}", path_string, e));
         }
     });
 

--- a/taglib2-sys/src/wrapper.cpp
+++ b/taglib2-sys/src/wrapper.cpp
@@ -2,6 +2,18 @@
 #include "../taglib/taglib/tag.h"
 #include "../taglib/taglib/fileref.h"
 #include "../taglib/taglib/toolkit/tpicturemap.h"
+#include "../taglib/taglib/toolkit/tdebuglistener.cpp"
+
+/// A debug listener which does nothing. It is used to mute debug output.
+class NopListener : public DebugListener {
+public:
+    virtual void printMessage(const String &msg) {
+        (void)msg;
+        // Do nothing.
+    }
+};
+
+NopListener nopListener;
 
 char *to_cstr(TagLib::String str) {
     return strdup(str.toCString(true));
@@ -45,6 +57,7 @@ void read_artwork(SongProperties *song, TagLib::PictureMap &map) {
 
 extern "C" {
     SongProperties *song_properties(const char *fileName) {
+        TagLib::setDebugListener(&nopListener);
         TagLib::FileRef file((TagLib::FileName) fileName);
 
         // Check if the file was opened


### PR DESCRIPTION
* Mutes the Taglib Debug Output
* Switch to ProgressBar.println to print lines above the progress bar which stick around as the bar is updated.