### PR TITLE
Improve CI Performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 aliases:
   - &save_cargo_cache
-    key: v3-cargo-{{ checksum "Cargo.lock" }}-{{ checksum "fixture_setup/Cargo.lock" }}
+    key: v4-cargo-{{ checksum "Cargo.lock" }}-{{ checksum "fixture_setup/Cargo.lock" }}
     paths:
       - target
       - fixture_setup/target
@@ -10,9 +10,7 @@ aliases:
 
   - &restore_cargo_cache
     keys:
-      - v3-cargo-{{ checksum "Cargo.lock" }}-{{ checksum "fixture_setup/Cargo.lock" }}
-      - v3-cargo-{{ checksum "Cargo.lock" }}-
-      - v3-cargo-
+      - v4-cargo-{{ checksum "Cargo.lock" }}-{{ checksum "fixture_setup/Cargo.lock" }}
 
   - &save_yarn_cache
     key: yarn-{{ checksum "fixture_setup/yarn.lock" }}


### PR DESCRIPTION
Changed ci to not inherit past cached assets. The cache is growing large
(~2.5 GB) and slowing the build down. Most of that is probably old
versions of libraries which aren't used anymore. The cache should be
purged on cache updates. This will slow down the buidls for cahce
misses, but improve the performance of builds for cache hits.

This has reduced the cache size to around 500MB build time to ~3m.
https://circleci.com/gh/forte-music/core/350