### PR TITLE
Fixed Path Handling

### DIFF
--- a/migrations/2018-05-14-200933_setup/up.sql
+++ b/migrations/2018-05-14-200933_setup/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE album (
   id BINARY(128) PRIMARY KEY NOT NULL,
-  artwork_path TEXT,
+  artwork_path BLOB,
   name TEXT NOT NULL,
   artist_id BINARY(128) NOT NULL REFERENCES artist(id),
   release_year INTEGER,
@@ -38,7 +38,7 @@ CREATE TABLE song (
   play_count INTEGER NOT NULL,
   last_played TIMESTAMP,
   liked BOOLEAN NOT NULL,
-  path TEXT UNIQUE NOT NULL,
+  path BLOB UNIQUE NOT NULL,
 
   UNIQUE(track_number, disk_number, album_id)
 );

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,7 +1,7 @@
 table! {
     album (id) {
         id -> Binary,
-        artwork_path -> Nullable<Text>,
+        artwork_path -> Nullable<Binary>,
         name -> Text,
         artist_id -> Binary,
         release_year -> Nullable<Integer>,
@@ -31,7 +31,7 @@ table! {
         play_count -> Integer,
         last_played -> Nullable<Timestamp>,
         liked -> Bool,
-        path -> Text,
+        path -> Binary,
     }
 }
 


### PR DESCRIPTION
Breaks Windows support. Windows support isn't a priority. Run it inside a VM or Ubuntu on Windows on Linux if you really want.

Closes #63

File paths are not necessarily valid strings, so they should be stored as an array of bytes instead of a valid string in the database.

On Unix OsStr and OsString map to an array of bytes. On Windows they map to an array of u16s. There isn't an easy way to store an array of u16s in SQLite. Also storing u16s on Windows and u8s on Linux would break database portability. I don't think we care but implementing serialization of u16s is annoying.