### PR TITLE
Embedded Web Interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,4 +197,4 @@ workflows:
       - download_web
       - build_artifacts:
           requires:
-            download_web
+            - download_web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,16 @@ aliases:
     keys:
       - v4-cargo-{{ checksum "Cargo.lock" }}-{{ checksum "fixture_setup/Cargo.lock" }}
 
+  - &save_artifact_cache
+    key: v1-artifact-{{ checksum "Cargo.lock" }}
+    paths:
+    - target
+    - ~/.cargo
+
+  - &restore_artifact_cache
+    keys:
+    - v1-artifact-{{ checksum "Cargo.lock" }}
+
   - &save_yarn_cache
     key: yarn-{{ checksum "fixture_setup/yarn.lock" }}
     paths:
@@ -131,6 +141,51 @@ jobs:
             wait-for --timeout=3600 localhost:8080 -- echo "Core started"
             yarn run forte-test-api http://localhost:8080/graphql --runInBand
 
+  download_web:
+    docker:
+    - image: garland/aws-cli-docker:1.15.47
+
+    steps:
+      - run:
+          name: Download Web
+          command: aws s3 cp s3://forte-web-artifacts/master/forte-web.tar.gz .
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - forte-web.tar.gz
+
+  build_artifacts:
+    docker:
+    - image: fortemusic/core-build
+
+    steps:
+      - checkout
+
+      - run:
+          name: Checkout Git Submodules
+          command: git submodule update --init
+
+      - restore_cache: *restore_artifact_cache
+
+      - attach_workspace:
+          at: ~/project
+
+      - run:
+          name: Unpack Web
+          command: |
+            mkdir web
+            tar -xzf forte-web.tar.gz -C web
+
+      - run:
+          name: Compile Core With Web
+          command: cargo build --release --features embed_web
+
+      - save_cache: *save_artifact_cache
+
+      - store_artifacts:
+          path: target/release/forte
+
 workflows:
   version: 2
   test:
@@ -139,3 +194,7 @@ workflows:
       - integration-test:
           requires:
             - build
+      - download_web
+      - build_artifacts:
+          requires:
+            download_web

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ cmake-build-debug/
 
 *.env
 *.sqlite
+
+web/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2-diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1421,6 +1422,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum resolv-conf 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c62bd95a41841efdf7fca2ae9951e64a8d8eae7e5da196d8ce489a2241491a92"
 "checksum ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe642b9dd1ba0038d78c4a3999d1ee56178b4d415c1e1fbaba83b06dce012f0"
+"checksum rust-embed 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5215cf7362127d1bc364a0df8ae8d9570197a53d21be01aa977ea67c1a3cfce8"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum ryu 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0568787116e13c652377b6846f5931454a363a8fdf8ae50463ee40935b278b"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ lto = true
 name = "forte"
 path = "src/bin/main.rs"
 
+[features]
+embed_web = ["rust-embed"]
+
 [dependencies]
 r2d2 = "0.8.0"
 r2d2-diesel = "1.0.0"
@@ -39,3 +42,4 @@ structopt = "0.2.10"
 app_dirs = "1.2.1"
 futures = "0.1.23"
 error-chain = "0.12.0"
+rust-embed={ version = "3.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ structopt = "0.2.10"
 app_dirs = "1.2.1"
 futures = "0.1.23"
 error-chain = "0.12.0"
-rust-embed={ version = "3.0.0", optional = true }
+rust-embed = { version = "3.0.0", optional = true }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -31,6 +31,10 @@ extern crate serde_json;
 extern crate tokio_process;
 extern crate uuid;
 
+#[cfg(feature = "embed_web")]
+#[macro_use]
+extern crate rust_embed;
+
 pub mod server;
 pub mod sync;
 

--- a/src/bin/server/mod.rs
+++ b/src/bin/server/mod.rs
@@ -50,14 +50,14 @@ pub fn serve(
             transcoder_addr.clone(),
             pool.clone(),
         )).resource("/graphql", |r| r.method(http::Method::POST).with(graphql))
-        .resource("/graphiql", |r| r.method(http::Method::GET).f(graphiql))
-        .register_transcode_handler(TranscodeTarget::MP3V0)
-        .register_transcode_handler(TranscodeTarget::AACV5)
-        .resource(&Song::get_raw_stream_url("{id}"), |r| {
-            r.method(http::Method::GET).with(streaming::song_handler)
-        }).resource(&Album::get_artwork_url("{id}"), |r| {
-            r.method(http::Method::GET).with(streaming::artwork_handler)
-        });
+            .resource("/graphiql", |r| r.method(http::Method::GET).f(graphiql))
+            .register_transcode_handler(TranscodeTarget::MP3V0)
+            .register_transcode_handler(TranscodeTarget::AACV5)
+            .resource(&Song::get_raw_stream_url("{id}"), |r| {
+                r.method(http::Method::GET).with(streaming::song_handler)
+            }).resource(&Album::get_artwork_url("{id}"), |r| {
+                r.method(http::Method::GET).with(streaming::artwork_handler)
+            });
 
         #[cfg(feature = "embed_web")]
         let app = app
@@ -66,8 +66,8 @@ pub fn serve(
 
         app
     }).bind(host)
-    .unwrap()
-    .start();
+        .unwrap()
+        .start();
 
     println!("Started Server on {}", host);
 

--- a/src/bin/server/mod.rs
+++ b/src/bin/server/mod.rs
@@ -55,7 +55,8 @@ pub fn serve(
             .register_transcode_handler(TranscodeTarget::AACV5)
             .resource(&Song::get_raw_stream_url("{id}"), |r| {
                 r.method(http::Method::GET).with(streaming::song_handler)
-            }).resource(&Album::get_artwork_url("{id}"), |r| {
+            })
+            .resource(&Album::get_artwork_url("{id}"), |r| {
                 r.method(http::Method::GET).with(streaming::artwork_handler)
             });
 

--- a/src/bin/server/web.rs
+++ b/src/bin/server/web.rs
@@ -1,0 +1,27 @@
+use actix_web::{HttpRequest, HttpResponse};
+use mime_guess::guess_mime_type;
+
+#[derive(RustEmbed)]
+#[folder = "web/"]
+struct WebAssets;
+
+/// Get a file from the embedded web assets
+fn handle_embedded_file(path: &str) -> HttpResponse {
+    match WebAssets::get(path) {
+        Some(content) => HttpResponse::Ok()
+            .content_type(guess_mime_type(path).to_string())
+            .body(content),
+        None => HttpResponse::NotFound().body("404 Not Found"),
+    }
+}
+
+/// Return the index page of the web interface
+pub fn web_interface_index<S>(_req: HttpRequest<S>) -> HttpResponse {
+    handle_embedded_file("index.html")
+}
+
+/// Return the requested page/file, if it exists.
+pub fn web_interface<S>(req: HttpRequest<S>) -> HttpResponse {
+    // Trim the preceding `/` in path
+    handle_embedded_file(&req.path()[1..])
+}

--- a/src/bin/server/web.rs
+++ b/src/bin/server/web.rs
@@ -1,4 +1,4 @@
-use actix_web::{App, HttpRequest, HttpResponse, http::Method };
+use actix_web::{http::Method, App, HttpRequest, HttpResponse};
 use mime_guess;
 use server::graphql::AppState;
 use server::WebHandlerAppExt;
@@ -30,7 +30,10 @@ pub fn web_interface<S>(req: HttpRequest<S>) -> HttpResponse {
 
 impl WebHandlerAppExt for App<AppState> {
     fn register_web_interface_handler(self) -> Self {
-        self.route("/", Method::GET, web_interface_index)
-            .route("/{_:.*}", Method::GET, web_interface)
+        self.route("/", Method::GET, web_interface_index).route(
+            "/{_:.*}",
+            Method::GET,
+            web_interface,
+        )
     }
 }

--- a/src/bin/server/web.rs
+++ b/src/bin/server/web.rs
@@ -1,5 +1,5 @@
 use actix_web::{App, HttpRequest, HttpResponse, http::Method };
-use mime_guess::guess_mime_type;
+use mime_guess;
 use server::graphql::AppState;
 use server::WebHandlerAppExt;
 
@@ -11,7 +11,7 @@ struct WebAssets;
 fn handle_embedded_file(path: &str) -> HttpResponse {
     match WebAssets::get(path) {
         Some(content) => HttpResponse::Ok()
-            .content_type(guess_mime_type(path).to_string())
+            .content_type(mime_guess::guess_mime_type(path).to_string())
             .body(content),
         None => HttpResponse::NotFound().body("404 Not Found"),
     }

--- a/src/bin/server/web.rs
+++ b/src/bin/server/web.rs
@@ -1,5 +1,7 @@
-use actix_web::{HttpRequest, HttpResponse};
+use actix_web::{App, HttpRequest, HttpResponse, http::Method };
 use mime_guess::guess_mime_type;
+use server::graphql::AppState;
+use server::WebHandlerAppExt;
 
 #[derive(RustEmbed)]
 #[folder = "web/"]
@@ -24,4 +26,11 @@ pub fn web_interface_index<S>(_req: HttpRequest<S>) -> HttpResponse {
 pub fn web_interface<S>(req: HttpRequest<S>) -> HttpResponse {
     // Trim the preceding `/` in path
     handle_embedded_file(&req.path()[1..])
+}
+
+impl WebHandlerAppExt for App<AppState> {
+    fn register_web_interface_handler(self) -> Self {
+        self.route("/", Method::GET, web_interface_index)
+            .route("/{_:.*}", Method::GET, web_interface)
+    }
 }


### PR DESCRIPTION
The web interface now can be embedded into Core.

There are some new steps in the CI which compile the latest version of web (master) and store the artifact on CircleCI.

You can enable the embedded web interface by copying the web interface files to a new folder called `web`, then compiling Core with the `embed_web` feature flag, like so:
```
cargo build --release --features embed_web
```