### PR TITLE
Make the UUID FromSql implementation more generic

### DIFF
--- a/src/models/id.rs
+++ b/src/models/id.rs
@@ -77,9 +77,13 @@ impl<DB: Backend + HasSqlType<Binary>> ToSql<Binary, DB> for UUID {
     }
 }
 
-impl FromSql<Binary, Sqlite> for UUID {
+impl<DB> FromSql<Binary, DB> for UUID
+where
+    DB: Backend + HasSqlType<Binary>,
+    Vec<u8>: FromSql<Binary, DB>,
+{
     fn from_sql(bytes: Option<&<Sqlite as Backend>::RawValue>) -> deserialize::Result<Self> {
-        let bytes_vec: Vec<u8> = <Vec<u8> as FromSql<Binary, Sqlite>>::from_sql(bytes)?;
+        let bytes_vec = Vec::<u8>::from_sql(bytes)?;
         Ok(UUID(Uuid::from_bytes(&bytes_vec)?))
     }
 }


### PR DESCRIPTION
The `ToSql` implementation is more generic because it uses `DB: Backend + HasSqlType<Binary>` bound. This pull request makes `FromSql` symmetric to `ToSql`.